### PR TITLE
UI: harmonize every screen onto the brand palette

### DIFF
--- a/src/main/java/com/asosiaciondeasis/animalesdeasis/Controller/SidebarController.java
+++ b/src/main/java/com/asosiaciondeasis/animalesdeasis/Controller/SidebarController.java
@@ -19,18 +19,36 @@ public class SidebarController implements IPortalAwareController {
      * This method initializes the sidebar by setting up event handlers for the labels.
      */
 
+    /** Style class that highlights the navigation item of the current screen. */
+    private static final String ACTIVE_CLASS = "active";
+
     @FXML
     public void initialize() {
         statsLabel.setOnMouseClicked(e -> {
             if (portalController != null) {
                 portalController.loadContent("/fxml/Statistics/StatisticsManagement.fxml");
+                markActive(statsLabel);
             }
         });
         animalsLabel.setOnMouseClicked(e -> {
             if (portalController != null) {
                 portalController.loadContent("/fxml/Animal/AnimalManagement.fxml");
+                markActive(animalsLabel);
             }
         });
+    }
+
+    /**
+     * Marks {@code selected} as the active navigation item and clears the flag from
+     * the others, so the sidebar always reflects which screen is open.
+     */
+    private void markActive(Label selected) {
+        for (Label item : new Label[]{statsLabel, animalsLabel}) {
+            item.getStyleClass().remove(ACTIVE_CLASS);
+        }
+        if (!selected.getStyleClass().contains(ACTIVE_CLASS)) {
+            selected.getStyleClass().add(ACTIVE_CLASS);
+        }
     }
 
     @Override

--- a/src/main/java/com/asosiaciondeasis/animalesdeasis/Controller/WelcomeController.java
+++ b/src/main/java/com/asosiaciondeasis/animalesdeasis/Controller/WelcomeController.java
@@ -1,39 +1,138 @@
 package com.asosiaciondeasis.animalesdeasis.Controller;
 
+import com.asosiaciondeasis.animalesdeasis.Config.FirebaseConfig;
+import com.asosiaciondeasis.animalesdeasis.Util.NetworkUtils;
 import javafx.application.Platform;
+import javafx.beans.binding.Bindings;
+import javafx.concurrent.Task;
 import javafx.event.ActionEvent;
+import javafx.geometry.Insets;
 import javafx.fxml.FXML;
 import javafx.fxml.FXMLLoader;
 import javafx.fxml.Initializable;
 import javafx.scene.Scene;
-import javafx.scene.layout.AnchorPane;
+import javafx.scene.control.Label;
+import javafx.scene.image.ImageView;
+import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 
 import java.io.IOException;
 import java.net.URL;
 import java.util.ResourceBundle;
 
+/**
+ * Controller for the landing screen.
+ *
+ * <p>Besides the "start" action it now offers shortcuts that open a specific
+ * section directly, and shows whether the app can sync right now. The
+ * connectivity probe performs network I/O, so it runs on a background
+ * {@link Task} — never on the JavaFX application thread.</p>
+ */
 public class WelcomeController implements Initializable {
 
+    /**
+     * Share of the window height taken by the artwork. Driving the image from the
+     * height (rather than the width) keeps the dog the same visual size on any
+     * monitor: binding to width made it swallow the screen when maximised.
+     */
+    private static final double ART_HEIGHT_RATIO = 0.42;
+
     private Stage stage;
-    @FXML private AnchorPane mainContainer;
+
+    @FXML private StackPane mainContainer;
+    @FXML private VBox heroBox;
+    @FXML private ImageView dogImageView;
+    @FXML private Label statusBadge;
 
     @Override
     public void initialize(URL location, ResourceBundle resources) {
+        bindArtworkSize();
+        checkConnectivityAsync();
     }
 
-    // Receive the stage from the main application
+    /**
+     * Scales the artwork with the window instead of using a hardcoded 900x600, so
+     * the dog keeps peeking from the bottom edge at any size without overlapping
+     * the content above it.
+     *
+     * <p>The hero's bottom padding is bound to the artwork height so the copy stays
+     * optically centred in the free space above the dog, rather than leaving a gap
+     * that grows on tall monitors.</p>
+     */
+    private void bindArtworkSize() {
+        dogImageView.fitHeightProperty().bind(
+                mainContainer.heightProperty().multiply(ART_HEIGHT_RATIO));
+        dogImageView.setFitWidth(0); // width follows from preserveRatio
+
+        heroBox.paddingProperty().bind(Bindings.createObjectBinding(
+                () -> new Insets(32, 32, dogImageView.getFitHeight() * 0.80, 32),
+                dogImageView.fitHeightProperty()));
+    }
+
+    /**
+     * Probes connectivity off the UI thread and updates the badge when done.
+     * Firebase may also be unavailable (missing credentials), in which case the
+     * app is offline-only regardless of the network.
+     */
+    private void checkConnectivityAsync() {
+        Task<Boolean> probe = new Task<>() {
+            @Override
+            protected Boolean call() {
+                return FirebaseConfig.isFirebaseAvailable() && NetworkUtils.isInternetAvailable();
+            }
+        };
+
+        probe.setOnSucceeded(e -> applyStatus(Boolean.TRUE.equals(probe.getValue())));
+        probe.setOnFailed(e -> applyStatus(false));
+
+        Thread thread = new Thread(probe, "welcome-connectivity-probe");
+        thread.setDaemon(true); // must not keep the JVM alive on exit
+        thread.start();
+    }
+
+    /** Updates the badge text/style. Called on the FX thread by the Task callbacks. */
+    private void applyStatus(boolean online) {
+        statusBadge.getStyleClass().removeAll("status-online", "status-offline");
+        if (online) {
+            statusBadge.setText("● En línea · los datos se sincronizan");
+            statusBadge.getStyleClass().add("status-online");
+        } else {
+            statusBadge.setText("● Sin conexión · se guardará localmente");
+            statusBadge.getStyleClass().add("status-offline");
+        }
+    }
+
+    /** Receives the stage from the main application. */
     public void setStage(Stage stage) {
         this.stage = stage;
     }
 
-
-    /**
-     * This method is called when the "Continue" button is clicked.
-     * It loads the PortalView.fxml and sets it as the current scene.
-     */
+    /** Opens the portal on its default (empty) content. */
     @FXML
     public void handleContinue(ActionEvent event) {
+        openPortal(null);
+    }
+
+    /** Shortcut: opens the portal directly on the animals section. */
+    @FXML
+    public void handleGoToAnimals(ActionEvent event) {
+        openPortal("/fxml/Animal/AnimalManagement.fxml");
+    }
+
+    /** Shortcut: opens the portal directly on the statistics section. */
+    @FXML
+    public void handleGoToStatistics(ActionEvent event) {
+        openPortal("/fxml/Statistics/StatisticsManagement.fxml");
+    }
+
+    /**
+     * Loads the portal and, when {@code initialContent} is provided, immediately
+     * navigates to that section so the user skips a redundant click.
+     *
+     * @param initialContent FXML path to open on arrival, or {@code null} for none
+     */
+    private void openPortal(String initialContent) {
         try {
             boolean wasMaximized = stage.isMaximized();
 
@@ -42,15 +141,18 @@ public class WelcomeController implements Initializable {
 
             stage.setMinWidth(1036);
             stage.setMinHeight(798);
-
             stage.setScene(scene);
+
+            if (initialContent != null) {
+                PortalController portalController = loader.getController();
+                // Deferred so the portal finishes its own initialize() first.
+                Platform.runLater(() -> portalController.loadContent(initialContent));
+            }
 
             if (wasMaximized) {
                 Platform.runLater(() -> {
                     stage.setMaximized(false);
-                    Platform.runLater(() -> {
-                        stage.setMaximized(true);
-                    });
+                    Platform.runLater(() -> stage.setMaximized(true));
                 });
             } else {
                 stage.centerOnScreen();

--- a/src/main/resources/css/Alerts.css
+++ b/src/main/resources/css/Alerts.css
@@ -80,5 +80,5 @@
 
 /* Info Alert Icon */
 .custom-alert.information .graphic {
-    -fx-text-fill: #3498db;
+    -fx-text-fill: #F2921D;
 }

--- a/src/main/resources/css/Animal/AnimalManagement.css
+++ b/src/main/resources/css/Animal/AnimalManagement.css
@@ -1,7 +1,7 @@
 
 .animal-management-container {
     -fx-padding: 20px;
-    -fx-background-color: linear-gradient(to bottom, #f8f9ff, #ffffff);
+    -fx-background-color: linear-gradient(to bottom, #fdf8f2, #ffffff);
 }
 
 .section-title {
@@ -173,12 +173,12 @@
 }
 
 .search-field:focused {
-    -fx-border-color: #3498db;
-    -fx-effect: dropshadow(three-pass-box, rgba(52, 152, 219, 0.3), 4, 0, 0, 0);
+    -fx-border-color: #F2921D;
+    -fx-effect: dropshadow(three-pass-box, rgba(242,146,29, 0.3), 4, 0, 0, 0);
 }
 
 .search-btn {
-    -fx-background-color: linear-gradient(to bottom, #3498db, #2980b9);
+    -fx-background-color: linear-gradient(to bottom, #F2921D, #E67E22);
     -fx-text-fill: white;
     -fx-font-size: 14px;
     -fx-padding: 8 12;
@@ -189,13 +189,13 @@
 }
 
 .search-btn:hover {
-    -fx-background-color: linear-gradient(to bottom, #2980b9, #21618c);
+    -fx-background-color: linear-gradient(to bottom, #E67E22, #D68910);
     -fx-scale-x: 1.1;
     -fx-scale-y: 1.1;
 }
 
 .show-all-btn {
-    -fx-background-color: linear-gradient(to bottom, #9b59b6, #8e44ad);
+    -fx-background-color: linear-gradient(to bottom, #F2921D, #E67E22);
     -fx-text-fill: white;
     -fx-font-size: 12px;
     -fx-font-weight: bold;
@@ -205,7 +205,7 @@
 }
 
 .show-all-btn:hover {
-    -fx-background-color: linear-gradient(to bottom, #8e44ad, #7d3c98);
+    -fx-background-color: linear-gradient(to bottom, #E67E22, #D68910);
 }
 .filter-checkbox {
     -fx-font-size: 12px;
@@ -213,7 +213,7 @@
 }
 
 .filter-checkbox:selected .box {
-    -fx-background-color: #4CAF50;
+    -fx-background-color: #27ae60;
 }
 
 .scan-chip-button {
@@ -221,13 +221,14 @@
     -fx-max-width: 35px;
     -fx-pref-width: 35px;
     -fx-font-size: 12px;
-    -fx-background-color: #007acc;
+    -fx-background-color: #F2921D;
     -fx-text-fill: white;
     -fx-background-radius: 4px;
+    -fx-cursor: hand;
 }
 
 .scan-chip-button:hover {
-    -fx-background-color: #005a9e;
+    -fx-background-color: #E67E22;
 }
 
 .filter-field {
@@ -283,14 +284,31 @@
     -fx-border-width: 0 0 1 0;
 }
 
+/* Warm hover tint keeps the table in the brand palette (it used to be a bluish
+   tone that clashed with the orange/brown identity). */
 .animal-table .table-row-cell:hover {
-    -fx-background-color: #f8f9ff;
+    -fx-background-color: #fdf6ec;
     -fx-cursor: hand;
 }
 
+/* Selected row: warm fill plus an orange rail on the left so the active record
+   is unmistakable even at a glance. */
 .animal-table .table-row-cell:selected {
     -fx-background-color: linear-gradient(to right, #fef7e6, #fff3e0);
     -fx-text-fill: #593414;
+    -fx-border-color: #F2921D transparent #f1f2f6 transparent;
+    -fx-border-width: 0 0 1 4;
+}
+
+.animal-table .table-row-cell:selected .table-cell {
+    -fx-text-fill: #593414;
+    -fx-font-weight: bold;
+}
+
+/* Empty-state text, instead of the default tiny grey label. */
+.animal-table .placeholder .label {
+    -fx-text-fill: #7f8c8d;
+    -fx-font-size: 15px;
 }
 
 .animal-table .table-cell {
@@ -338,11 +356,11 @@
 }
 
 .detail-btn {
-    -fx-background-color: linear-gradient(to bottom, #0077B6, #005577);
+    -fx-background-color: linear-gradient(to bottom, #7a4a1d, #593414);
 }
 
 .detail-btn:hover {
-    -fx-background-color: linear-gradient(to bottom, #005577, #003d55);
+    -fx-background-color: linear-gradient(to bottom, #593414, #4a2a11);
     -fx-scale-x: 1.05;
     -fx-scale-y: 1.05;
 }

--- a/src/main/resources/css/Animal/CreateForm.css
+++ b/src/main/resources/css/Animal/CreateForm.css
@@ -52,7 +52,7 @@
 
 .icon-label {
     -fx-font-size: 48px;
-    -fx-text-fill: #3b82f6;
+    -fx-text-fill: #F2921D;
 }
 
 .form-title {
@@ -127,9 +127,9 @@
 }
 
 .custom-field:focused {
-    -fx-border-color: #3b82f6;
+    -fx-border-color: #F2921D;
     -fx-border-width: 2.5px;
-    -fx-effect: dropshadow(gaussian, rgba(59,130,246,0.25), 6, 0, 0, 0);
+    -fx-effect: dropshadow(gaussian, rgba(242,146,29,0.25), 6, 0, 0, 0);
 }
 
 .custom-field:hover {
@@ -152,9 +152,9 @@
 }
 
 .custom-combo:focused {
-    -fx-border-color: #3b82f6;
+    -fx-border-color: #F2921D;
     -fx-border-width: 2.5px;
-    -fx-effect: dropshadow(gaussian, rgba(59,130,246,0.25), 6, 0, 0, 0);
+    -fx-effect: dropshadow(gaussian, rgba(242,146,29,0.25), 6, 0, 0, 0);
 }
 
 .custom-combo:hover {
@@ -189,9 +189,9 @@
 }
 
 .custom-date:focused {
-    -fx-border-color: #3b82f6;
+    -fx-border-color: #F2921D;
     -fx-border-width: 2.5px;
-    -fx-effect: dropshadow(gaussian, rgba(59,130,246,0.25), 6, 0, 0, 0);
+    -fx-effect: dropshadow(gaussian, rgba(242,146,29,0.25), 6, 0, 0, 0);
 }
 
 .custom-date:hover {
@@ -223,9 +223,9 @@
 }
 
 .custom-spinner:focused {
-    -fx-border-color: #3b82f6;
+    -fx-border-color: #F2921D;
     -fx-border-width: 2.5px;
-    -fx-effect: dropshadow(gaussian, rgba(59,130,246,0.25), 6, 0, 0, 0);
+    -fx-effect: dropshadow(gaussian, rgba(242,146,29,0.25), 6, 0, 0, 0);
 }
 
 .custom-spinner:hover {
@@ -262,9 +262,9 @@
 }
 
 .custom-textarea:focused {
-    -fx-border-color: #3b82f6;
+    -fx-border-color: #F2921D;
     -fx-border-width: 2.5px;
-    -fx-effect: dropshadow(gaussian, rgba(59,130,246,0.25), 6, 0, 0, 0);
+    -fx-effect: dropshadow(gaussian, rgba(242,146,29,0.25), 6, 0, 0, 0);
 }
 
 .custom-textarea:hover {
@@ -281,7 +281,7 @@
 }
 
 .save-button {
-    -fx-background-color: #3b82f6;
+    -fx-background-color: #F2921D;
     -fx-text-fill: white;
     -fx-font-size: 16px;
     -fx-font-weight: bold;
@@ -290,12 +290,12 @@
     -fx-background-radius: 8px;
     -fx-cursor: hand;
     -fx-font-family: "Segoe UI", sans-serif;
-    -fx-effect: dropshadow(gaussian, rgba(59,130,246,0.3), 6, 0, 0, 2);
+    -fx-effect: dropshadow(gaussian, rgba(242,146,29,0.3), 6, 0, 0, 2);
 }
 
 .save-button:hover {
-    -fx-background-color: #2563eb;
-    -fx-effect: dropshadow(gaussian, rgba(59,130,246,0.4), 8, 0, 0, 3);
+    -fx-background-color: #E67E22;
+    -fx-effect: dropshadow(gaussian, rgba(242,146,29,0.4), 8, 0, 0, 3);
     -fx-scale-y: 1.02;
     -fx-scale-x: 1.02;
 }
@@ -326,7 +326,7 @@
 }
 
 .scan-button {
-    -fx-background-color: #10b981;
+    -fx-background-color: #27ae60;
     -fx-text-fill: white;
     -fx-font-size: 14px;
     -fx-font-weight: 500;
@@ -335,26 +335,17 @@
     -fx-background-radius: 8px;
     -fx-cursor: hand;
     -fx-font-family: "Segoe UI", sans-serif;
-    -fx-effect: dropshadow(gaussian, rgba(16,185,129,0.3), 4, 0, 0, 1);
+    -fx-effect: dropshadow(gaussian, rgba(39,174,96,0.3), 4, 0, 0, 1);
 }
 
 .scan-button:hover {
-    -fx-background-color: #059669;
-    -fx-effect: dropshadow(gaussian, rgba(16,185,129,0.4), 6, 0, 0, 2);
-    -text-fill: white;
-    -fx-font-size: 14px;
-    -fx-font-weight: 500;
-    -fx-padding: 12px 16px;
-    -fx-border-radius: 8px;
-    -fx-background-radius: 8px;
-    -fx-cursor: hand;
-    -fx-font-family: "Segoe UI", sans-serif;
-    -fx-effect: dropshadow(gaussian, rgba(16, 185, 129, 0.3), 4, 0, 0, 1);
+    -fx-background-color: #229954;
+    -fx-effect: dropshadow(gaussian, rgba(39,174,96,0.4), 6, 0, 0, 2);
 }
 
-.scan-button:hover {
-    -fx-background-color: derive(#10b981, -10%);
-    -fx-effect: dropshadow(gaussian, rgba(16, 185, 129, 0.4), 6, 0, 0, 2);
+.scan-button:pressed {
+    -fx-scale-x: 0.98;
+    -fx-scale-y: 0.98;
 }
 
 /* Grid personalizado */
@@ -363,33 +354,6 @@
     -fx-vgap: 20px;
 }
 
-/* Animaciones suaves */
-.custom-field,
-.custom-combo,
-.custom-date,
-.custom-spinner,
-.custom-textarea,
-.save-button,
-.cancel-button,
-.scan-button {
-}
-
-/* Responsive para pantallas pequeñas */
-@media (max-width: 600px) {
-    .form-card {
-        -fx-padding: 20px;
-    }
-    
-    .form-grid {
-        -fx-hgap: 16px;
-        -fx-vgap: 16px;
-    }
-    
-    .form-title {
-        -fx-font-size: 24px;
-    }
-    
-    .section-title {
-        -fx-font-size: 18px;
-    }
-}
+/* NOTE: JavaFX CSS has no @media support, so the responsive block that used to
+   live here never applied and was removed. Size adaptation is handled by the
+   layout instead (ScrollPane with fit-to-width). */

--- a/src/main/resources/css/Animal/DetailAnimal.css
+++ b/src/main/resources/css/Animal/DetailAnimal.css
@@ -24,7 +24,7 @@
 }
 
 .detail-separator {
-    -fx-background-color: #3498db;
+    -fx-background-color: #F2921D;
     -fx-pref-height: 3;
     -fx-background-radius: 2;
 }
@@ -119,12 +119,12 @@
 }
 
 .detail-edit-button {
-    -fx-background-color: #3498db;
+    -fx-background-color: #F2921D;
     -fx-text-fill: white;
 }
 
 .detail-edit-button:hover {
-    -fx-background-color: #2980b9;
+    -fx-background-color: #E67E22;
     -fx-opacity: 0.9;
 }
 
@@ -170,7 +170,7 @@
 }
 .copy-icon-button:hover {
     -fx-background-color: #ecf0f1;
-    -fx-border-color: #3498db;
+    -fx-border-color: #F2921D;
 }
 
 .copy-icon-button:pressed {

--- a/src/main/resources/css/Animal/EditForm.css
+++ b/src/main/resources/css/Animal/EditForm.css
@@ -328,7 +328,7 @@
 }
 
 .scan-button {
-    -fx-background-color: #10b981;
+    -fx-background-color: #27ae60;
     -fx-text-fill: white;
     -fx-font-size: 13px;
     -fx-font-weight: 500;
@@ -337,7 +337,7 @@
     -fx-background-radius: 8px;
     -fx-cursor: hand;
     -fx-font-family: "Segoe UI", sans-serif;
-    -fx-effect: dropshadow(gaussian, rgba(16,185,129,0.3), 4, 0, 0, 1);
+    -fx-effect: dropshadow(gaussian, rgba(39,174,96,0.3), 4, 0, 0, 1);
     -fx-min-width: 110px;
     -fx-pref-width: 110px;
     -fx-min-height: 42px;
@@ -345,8 +345,8 @@
 }
 
 .scan-button:hover {
-    -fx-background-color: #059669;
-    -fx-effect: dropshadow(gaussian, rgba(16,185,129,0.4), 6, 0, 0, 2);
+    -fx-background-color: #229954;
+    -fx-effect: dropshadow(gaussian, rgba(39,174,96,0.4), 6, 0, 0, 2);
     -fx-scale-y: 1.02;
     -fx-scale-x: 1.02;
 }
@@ -400,21 +400,6 @@
 }
 
 /* Responsive para pantallas pequeñas */
-@media (max-width: 600px) {
-    .form-card {
-        -fx-padding: 20px;
-    }
-
-    .form-grid {
-        -fx-hgap: 16px;
-        -fx-vgap: 16px;
-    }
-
-    .form-title {
-        -fx-font-size: 24px;
-    }
-
-    .section-title {
-        -fx-font-size: 18px;
-    }
-}
+/* NOTE: JavaFX CSS has no @media support, so the responsive block that used to
+   live here never applied and was removed. Size adaptation is handled by the
+   layout instead. */

--- a/src/main/resources/css/Portal.css
+++ b/src/main/resources/css/Portal.css
@@ -54,16 +54,30 @@
 
 
 .sidebar-item {
+    -fx-font-family: "Segoe UI", sans-serif;
     -fx-font-size: 18px;
     -fx-text-fill: white;
-    -fx-padding: 10 15;
+    -fx-padding: 12 16;
     -fx-cursor: hand;
     -fx-alignment: CENTER_LEFT;
+    -fx-max-width: Infinity;
+    -fx-background-radius: 8;
+    /* Transparent border keeps the box the same size as the hover/active state,
+       so items no longer shift by a pixel when highlighted. */
+    -fx-border-color: transparent;
+    -fx-border-width: 0 0 0 4;
 }
 
-
 .sidebar-item:hover {
-    -fx-background-color: #F24E29;
+    -fx-background-color: rgba(255,255,255,0.22);
     -fx-text-fill: white;
-    -fx-background-radius: 5;
+}
+
+/* Active/selected navigation item: a white left rail + stronger surface makes
+   the current screen obvious, which the sidebar previously did not indicate. */
+.sidebar-item:pressed,
+.sidebar-item.active {
+    -fx-background-color: rgba(255,255,255,0.32);
+    -fx-border-color: white;
+    -fx-font-weight: bold;
 }

--- a/src/main/resources/css/Splash.css
+++ b/src/main/resources/css/Splash.css
@@ -1,5 +1,5 @@
 .splash-container {
-    -fx-background-color: #f0f8ff;
+    -fx-background-color: #fffaf3;
     -fx-padding: 50;
 }
 

--- a/src/main/resources/css/Statistics/StatisticsDashboard.css
+++ b/src/main/resources/css/Statistics/StatisticsDashboard.css
@@ -26,7 +26,7 @@
 }
 
 .header-icon {
-    -fx-icon-color: #3498db;
+    -fx-icon-color: #F2921D;
 }
 
 .year-label {
@@ -46,7 +46,7 @@
 }
 
 .year-combo:focused {
-    -fx-border-color: #3498db;
+    -fx-border-color: #F2921D;
     -fx-background-color: #ffffff;
 }
 
@@ -59,26 +59,26 @@
    BUTTONS
    ================================= */
 .btn-refresh {
-    -fx-background-color: linear-gradient(to bottom, #3498db, #2980b9);
+    -fx-background-color: linear-gradient(to bottom, #F2921D, #E67E22);
     -fx-text-fill: white;
     -fx-background-radius: 10;
     -fx-padding: 12 18;
     -fx-font-size: 13px;
     -fx-font-weight: 600;
-    -fx-effect: dropshadow(gaussian, rgba(52,152,219,0.3), 6, 0, 0, 2);
+    -fx-effect: dropshadow(gaussian, rgba(242,146,29,0.3), 6, 0, 0, 2);
     -fx-cursor: hand;
     -fx-border-radius: 10;
 }
 
 .btn-refresh:hover {
-    -fx-background-color: linear-gradient(to bottom, #2980b9, #21618c);
-    -fx-effect: dropshadow(gaussian, rgba(52,152,219,0.4), 8, 0, 0, 3);
+    -fx-background-color: linear-gradient(to bottom, #E67E22, #D68910);
+    -fx-effect: dropshadow(gaussian, rgba(242,146,29,0.4), 8, 0, 0, 3);
     -fx-scale-y: 1.02;
     -fx-scale-x: 1.02;
 }
 
 .btn-refresh:pressed {
-    -fx-background-color: #21618c;
+    -fx-background-color: #D68910;
     -fx-scale-y: 0.98;
     -fx-scale-x: 0.98;
 }
@@ -190,7 +190,7 @@
 }
 
 .monthly-chart .default-color0.chart-bar {
-    -fx-background-color: linear-gradient(to bottom, #2980b9, #1f4e79);
+    -fx-background-color: linear-gradient(to bottom, #E67E22, #D68910);
     -fx-background-radius: 4 4 0 0;
 }
 
@@ -260,7 +260,7 @@
 }
 
 .status-icon {
-    -fx-icon-color: #17a2b8;
+    -fx-icon-color: #F2921D;
 }
 
 .status-text {
@@ -289,22 +289,6 @@
 /* =================================
    RESPONSIVE ADJUSTMENTS
    ================================= */
-@media (max-width: 1200px) {
-    .dashboard-title {
-        -fx-font-size: 26px;
-    }
-
-    .chart-title {
-        -fx-font-size: 16px;
-    }
-}
-
-@media (max-width: 800px) {
-    .header-section {
-        -fx-padding: 20 25;
-    }
-
-    .chart-container {
-        -fx-padding: 20;
-    }
-}
+/* NOTE: JavaFX CSS has no @media support, so the responsive block that used to
+   live here never applied and was removed. Size adaptation is handled by the
+   layout instead. */

--- a/src/main/resources/css/Vaccine/CreateForm.css
+++ b/src/main/resources/css/Vaccine/CreateForm.css
@@ -56,8 +56,8 @@
 }
 
 .vaccine-create-textfield:focused {
-    -fx-border-color: #3498db;
-    -fx-effect: dropshadow(gaussian, rgba(52, 152, 219, 0.3), 5, 0, 0, 0);
+    -fx-border-color: #F2921D;
+    -fx-effect: dropshadow(gaussian, rgba(242,146,29, 0.3), 5, 0, 0, 0);
 }
 
 .vaccine-create-datepicker {
@@ -71,8 +71,8 @@
 }
 
 .vaccine-create-datepicker:focused {
-    -fx-border-color: #3498db;
-    -fx-effect: dropshadow(gaussian, rgba(52, 152, 219, 0.3), 5, 0, 0, 0);
+    -fx-border-color: #F2921D;
+    -fx-effect: dropshadow(gaussian, rgba(242,146,29, 0.3), 5, 0, 0, 0);
 }
 
 /* Button Styles */

--- a/src/main/resources/css/Vaccine/EditForm.css
+++ b/src/main/resources/css/Vaccine/EditForm.css
@@ -67,9 +67,9 @@
 }
 
 .vaccine-edit-textfield:focused {
-    -fx-border-color: #3498db;
+    -fx-border-color: #F2921D;
     -fx-background-color: #f8f9fa;
-    -fx-effect: dropshadow(gaussian, rgba(52, 152, 219, 0.3), 5, 0, 0, 0);
+    -fx-effect: dropshadow(gaussian, rgba(242,146,29, 0.3), 5, 0, 0, 0);
 }
 
 .vaccine-edit-textfield:hover {
@@ -93,9 +93,9 @@
 }
 
 .vaccine-edit-datepicker:focused .text-field {
-    -fx-border-color: #3498db;
+    -fx-border-color: #F2921D;
     -fx-background-color: #f8f9fa;
-    -fx-effect: dropshadow(gaussian, rgba(52, 152, 219, 0.3), 5, 0, 0, 0);
+    -fx-effect: dropshadow(gaussian, rgba(242,146,29, 0.3), 5, 0, 0, 0);
 }
 
 .vaccine-edit-datepicker:hover .text-field {
@@ -177,26 +177,8 @@
     -fx-effect: none;
 }
 
-/* Responsive adjustments */
-@media (max-width: 600px) {
-    .vaccine-edit-container {
-        -fx-min-width: 320px;
-        -fx-max-width: 380px;
-        -fx-padding: 20px;
-    }
-
-    .vaccine-edit-textfield, .vaccine-edit-datepicker {
-        -fx-pref-width: 220px;
-    }
-
-    .vaccine-edit-buttons {
-        -fx-spacing: 10px;
-    }
-
-    .vaccine-edit-button-base {
-        -fx-pref-width: 80px;
-    }
-}
+/* NOTE: JavaFX CSS has no @media support; the responsive block that used to live
+   here never applied and was removed. */
 
 /* Focus and validation styles */
 .vaccine-edit-textfield.error {

--- a/src/main/resources/css/Vaccine/VaccineManagement.css
+++ b/src/main/resources/css/Vaccine/VaccineManagement.css
@@ -31,7 +31,7 @@
 }
 
 .vaccine-separator {
-    -fx-background-color: #3498db;
+    -fx-background-color: #F2921D;
     -fx-pref-height: 3;
     -fx-background-radius: 2;
 }
@@ -132,23 +132,35 @@
     -fx-cell-size: 40px;
 }
 
+/* Warm hover + orange selection rail, matching the animals table so both
+   listings behave and read identically (this row used to select in blue). */
 .vaccine-table .table-row-cell:hover {
-    -fx-background-color: #f8f9fa;
+    -fx-background-color: #fdf6ec;
+    -fx-cursor: hand;
 }
 
 .vaccine-table .table-row-cell:selected {
-    -fx-background-color: #e3f2fd;
-    -fx-border-color: #2196f3;
-    -fx-border-width: 1;
-    -fx-text-fill: #2c3e50;
+    -fx-background-color: linear-gradient(to right, #fef7e6, #fff3e0);
+    -fx-border-color: #F2921D transparent #ecf0f1 transparent;
+    -fx-border-width: 0 0 1 4;
 }
 
 .vaccine-table .table-cell {
     -fx-font-size: 13px;
-    -fx-text-fill: black !important;
+    -fx-text-fill: #2c3e50;
     -fx-padding: 8;
     -fx-alignment: CENTER;
     -fx-text-alignment: center;
+}
+
+.vaccine-table .table-row-cell:selected .table-cell {
+    -fx-text-fill: #593414;
+    -fx-font-weight: bold;
+}
+
+.vaccine-table .placeholder .label {
+    -fx-text-fill: #7f8c8d;
+    -fx-font-size: 15px;
 }
 
 .vaccine-table .table-row-cell:even {
@@ -238,7 +250,7 @@
 .summary-value {
     -fx-font-size: 24px;
     -fx-font-weight: bold;
-    -fx-text-fill: #3498db;
+    -fx-text-fill: #F2921D;
 }
 
 /* Navigation Button - Simple style without container */

--- a/src/main/resources/css/Welcome.css
+++ b/src/main/resources/css/Welcome.css
@@ -1,24 +1,32 @@
+/* ===========================================================================
+   Welcome / landing screen
+   Uses the shared brand tokens from theme.css (loaded first by the FXML).
+   =========================================================================== */
 
 .main-container {
-    -fx-background-color: #ffffff;
+    -fx-background-color: linear-gradient(to bottom, #ffffff, #fffaf3);
     -fx-min-width: 1036px;
     -fx-min-height: 798px;
 }
+
 .text-container {
     -fx-alignment: CENTER;
-    -fx-spacing: 15px;
-    -fx-padding: 20px;
+    -fx-spacing: 18px;
+    -fx-padding: 24px;
 }
 
+/* The title now shares the app's UI typeface (the rest of the app uses Segoe UI)
+   and the brand brown, instead of an unrelated 80px serif. */
 .title-label {
-    -fx-font-family: "Times New Roman", "Georgia", serif;
-    -fx-font-size: 80px;
+    -fx-font-family: "Segoe UI Semibold", "Segoe UI", "Helvetica Neue", sans-serif;
+    -fx-font-size: 64px;
     -fx-font-weight: bold;
-    -fx-text-fill: #2c2c2c;
+    -fx-text-fill: #593414;
     -fx-alignment: center;
 }
+
 .dog-image {
-    /* A soft drop shadow lifts the hero image off the white background.
+    /* A soft drop shadow lifts the hero image off the light background.
        (The previous rule declared this shadow and then cancelled it with
        `-fx-effect: none`, so no shadow ever rendered.) */
     -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.2), 10, 0, 0, 5);
@@ -26,26 +34,36 @@
 }
 
 .slogan-label {
-    -fx-font-family: "Arial", "Helvetica", sans-serif;
-        -fx-font-size: 22px;
-        -fx-font-weight: normal;
-        -fx-text-fill: #666666;
-        -fx-font-style: italic;
+    -fx-font-family: "Segoe UI", "Helvetica Neue", sans-serif;
+    -fx-font-size: 22px;
+    -fx-font-weight: normal;
+    -fx-text-fill: #7a6a5a;
+    -fx-font-style: italic;
 }
 
 .continue-button {
+    -fx-font-family: "Segoe UI", sans-serif;
     -fx-font-size: 18px;
-        -fx-font-weight: bold;
-        -fx-padding: 12px 24px;
-        -fx-background-radius: 30px;
-        -fx-text-fill: white;
-        -fx-background-color: #F2921D;
-        -fx-cursor: hand;
-        -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.2), 6, 0.3, 0, 2);
-        -fx-border-color: transparent;
+    -fx-font-weight: bold;
+    -fx-padding: 14px 36px;
+    -fx-background-radius: 30px;
+    -fx-text-fill: white;
+    -fx-background-color: linear-gradient(to bottom, #F2921D, #E67E22);
+    -fx-cursor: hand;
+    -fx-effect: dropshadow(gaussian, rgba(242,146,29,0.35), 8, 0.2, 0, 3);
+    -fx-border-color: transparent;
 }
+
 .continue-button:hover {
-    -fx-background-color: #F28322;
-        -fx-scale-x: 1.05;
-        -fx-scale-y: 1.05;
+    -fx-background-color: linear-gradient(to bottom, #E67E22, #D68910);
+    -fx-effect: dropshadow(gaussian, rgba(242,146,29,0.5), 12, 0.3, 0, 4);
+    -fx-scale-x: 1.04;
+    -fx-scale-y: 1.04;
+}
+
+/* Pressed state gives tactile feedback that was missing before. */
+.continue-button:pressed {
+    -fx-background-color: #D68910;
+    -fx-scale-x: 0.99;
+    -fx-scale-y: 0.99;
 }

--- a/src/main/resources/css/Welcome.css
+++ b/src/main/resources/css/Welcome.css
@@ -1,69 +1,146 @@
 /* ===========================================================================
    Welcome / landing screen
-   Uses the shared brand tokens from theme.css (loaded first by the FXML).
+   Two-column hero using the brand tokens from theme.css (loaded first).
+   Brand: orange #F2921D, brown #593414.
    =========================================================================== */
 
 .main-container {
-    -fx-background-color: linear-gradient(to bottom, #ffffff, #fffaf3);
+    /* Soft warm wash instead of flat white: gives the hero depth without
+       competing with the artwork. */
+    -fx-background-color: linear-gradient(from 0% 0% to 100% 100%, #fffdfa, #fdf1e0);
     -fx-min-width: 1036px;
     -fx-min-height: 798px;
 }
 
-.text-container {
-    -fx-alignment: CENTER;
-    -fx-spacing: 18px;
-    -fx-padding: 24px;
+.hero {
+    -fx-background-color: transparent;
 }
 
-/* The title now shares the app's UI typeface (the rest of the app uses Segoe UI)
-   and the brand brown, instead of an unrelated 80px serif. */
+/* ── Brand block ───────────────────────────────────────────────────────── */
+
+.brand-logo {
+    -fx-effect: dropshadow(gaussian, rgba(89,52,20,0.18), 8, 0, 0, 3);
+}
+
 .title-label {
     -fx-font-family: "Segoe UI Semibold", "Segoe UI", "Helvetica Neue", sans-serif;
-    -fx-font-size: 64px;
+    -fx-font-size: 56px;
     -fx-font-weight: bold;
     -fx-text-fill: #593414;
-    -fx-alignment: center;
+    -fx-text-alignment: center;
 }
 
-.dog-image {
-    /* A soft drop shadow lifts the hero image off the light background.
-       (The previous rule declared this shadow and then cancelled it with
-       `-fx-effect: none`, so no shadow ever rendered.) */
-    -fx-effect: dropshadow(gaussian, rgba(0,0,0,0.2), 10, 0, 0, 5);
-    -fx-opacity: 1.0;
+/* Short brand-colored rule under the title, a cleaner separator than spacing. */
+.title-rule {
+    -fx-background-color: linear-gradient(to right, #F2921D, #E67E22);
+    -fx-min-height: 5px;
+    -fx-max-height: 5px;
+    -fx-min-width: 84px;
+    -fx-max-width: 84px;
+    -fx-background-radius: 3px;
 }
 
 .slogan-label {
     -fx-font-family: "Segoe UI", "Helvetica Neue", sans-serif;
     -fx-font-size: 22px;
-    -fx-font-weight: normal;
-    -fx-text-fill: #7a6a5a;
     -fx-font-style: italic;
+    -fx-text-fill: #8a6d4f;
+    -fx-text-alignment: center;
 }
+
+.hero-description {
+    -fx-font-family: "Segoe UI", sans-serif;
+    -fx-font-size: 15px;
+    -fx-text-fill: #7a6a5a;
+    -fx-line-spacing: 3px;
+    -fx-text-alignment: center;
+}
+
+/* ── Actions ───────────────────────────────────────────────────────────── */
 
 .continue-button {
     -fx-font-family: "Segoe UI", sans-serif;
     -fx-font-size: 18px;
     -fx-font-weight: bold;
-    -fx-padding: 14px 36px;
+    -fx-padding: 15px 40px;
     -fx-background-radius: 30px;
     -fx-text-fill: white;
     -fx-background-color: linear-gradient(to bottom, #F2921D, #E67E22);
     -fx-cursor: hand;
-    -fx-effect: dropshadow(gaussian, rgba(242,146,29,0.35), 8, 0.2, 0, 3);
+    -fx-effect: dropshadow(gaussian, rgba(242,146,29,0.4), 10, 0.2, 0, 4);
     -fx-border-color: transparent;
 }
 
 .continue-button:hover {
     -fx-background-color: linear-gradient(to bottom, #E67E22, #D68910);
-    -fx-effect: dropshadow(gaussian, rgba(242,146,29,0.5), 12, 0.3, 0, 4);
-    -fx-scale-x: 1.04;
-    -fx-scale-y: 1.04;
+    -fx-effect: dropshadow(gaussian, rgba(242,146,29,0.55), 14, 0.3, 0, 5);
+    -fx-scale-x: 1.03;
+    -fx-scale-y: 1.03;
 }
 
-/* Pressed state gives tactile feedback that was missing before. */
 .continue-button:pressed {
     -fx-background-color: #D68910;
     -fx-scale-x: 0.99;
     -fx-scale-y: 0.99;
 }
+
+/* Secondary shortcuts: outlined so they read as lower priority than the
+   primary call to action, while still being obviously clickable. */
+.quick-button {
+    -fx-font-family: "Segoe UI", sans-serif;
+    -fx-font-size: 14px;
+    -fx-font-weight: bold;
+    -fx-padding: 11px 22px;
+    -fx-background-radius: 24px;
+    -fx-border-radius: 24px;
+    -fx-background-color: rgba(255,255,255,0.75);
+    -fx-text-fill: #593414;
+    -fx-border-color: #e7d3b8;
+    -fx-border-width: 1.5px;
+    -fx-cursor: hand;
+}
+
+.quick-button:hover {
+    -fx-background-color: white;
+    -fx-border-color: #F2921D;
+    -fx-text-fill: #C1660F;
+}
+
+.quick-button:pressed {
+    -fx-background-color: #fdf1e0;
+    -fx-scale-x: 0.98;
+    -fx-scale-y: 0.98;
+}
+
+/* ── Connectivity badge ────────────────────────────────────────────────── */
+
+.status-badge {
+    -fx-font-family: "Segoe UI", sans-serif;
+    -fx-font-size: 12.5px;
+    -fx-font-weight: bold;
+    -fx-padding: 6px 14px;
+    -fx-background-radius: 20px;
+    /* Neutral placeholder shown while the probe runs. */
+    -fx-background-color: rgba(0,0,0,0.05);
+    -fx-text-fill: #7a6a5a;
+}
+
+.status-badge.status-online {
+    -fx-background-color: #e8f6ed;
+    -fx-text-fill: #1e8449;
+}
+
+.status-badge.status-offline {
+    -fx-background-color: #fdf0e6;
+    -fx-text-fill: #b0641a;
+}
+
+/* ── Right column ──────────────────────────────────────────────────────── */
+
+/* No drop shadow here on purpose: the PNG is cropped flat at the bottom edge, so
+   a shadow traced a hard rectangle around the artwork instead of following the
+   dog's silhouette. */
+.dog-image {
+    -fx-opacity: 1.0;
+}
+

--- a/src/main/resources/fxml/WelcomeView.fxml
+++ b/src/main/resources/fxml/WelcomeView.fxml
@@ -4,25 +4,81 @@
 <?import javafx.scene.image.ImageView?>
 <?import javafx.scene.layout.*?>
 <?import javafx.scene.image.Image?>
+<?import javafx.geometry.Insets?>
 
-<AnchorPane fx:id="mainContainer" xmlns="http://javafx.com/javafx/11.0.1" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.asosiaciondeasis.animalesdeasis.Controller.WelcomeController" stylesheets="@/css/theme.css, @/css/Welcome.css" styleClass="main-container">
-    <children>
-        <VBox alignment="CENTER" spacing="20.0" AnchorPane.topAnchor="150.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
-            <children>
-                <Label styleClass="title-label" text="Animales de Asís" />
-                <Label styleClass="slogan-label" text="Rescatando vidas, un hogar a la vez." wrapText="true"/>
-                <Button fx:id="continueButton"
-                        text="Continuar →"
-                        onAction="#handleContinue"
-                        styleClass="continue-button" />
-            </children>
+<!--
+  Welcome / landing screen.
+
+  The artwork is a dog peeking up from the bottom edge (transparent PNG, cropped
+  at the muzzle on purpose), so it is anchored to the bottom of the stage across
+  the full width. The content sits above it in a StackPane overlay, and both
+  scale with the window via bindings in WelcomeController — replacing the old
+  fixed AnchorPane offsets that overlapped on smaller screens.
+-->
+<StackPane fx:id="mainContainer"
+           xmlns="http://javafx.com/javafx/11.0.1"
+           xmlns:fx="http://javafx.com/fxml/1"
+           fx:controller="com.asosiaciondeasis.animalesdeasis.Controller.WelcomeController"
+           stylesheets="@/css/theme.css, @/css/Welcome.css"
+           styleClass="main-container">
+
+    <!-- ── Artwork: pinned to the bottom edge, full bleed ── -->
+    <ImageView fx:id="dogImageView" preserveRatio="true" pickOnBounds="false"
+               StackPane.alignment="BOTTOM_CENTER" styleClass="dog-image">
+        <image>
+            <Image url="@/images/DogWelcomePage.png"/>
+        </image>
+    </ImageView>
+
+    <!-- ── Content overlay ── -->
+    <!-- Vertically centred in the space above the artwork; the bottom padding that
+         reserves that space is bound in WelcomeController. -->
+    <VBox fx:id="heroBox" alignment="CENTER" spacing="16.0" styleClass="hero" maxWidth="720.0">
+
+        <ImageView fitHeight="86.0" preserveRatio="true" styleClass="brand-logo">
+            <image>
+                <Image url="@/images/AdeAsisLogo.png"/>
+            </image>
+        </ImageView>
+
+        <Label styleClass="title-label" text="Animales de Asís" wrapText="true"/>
+
+        <Region styleClass="title-rule"/>
+
+        <Label styleClass="slogan-label"
+               text="Rescatando vidas, un hogar a la vez."
+               wrapText="true"/>
+
+        <Label styleClass="hero-description" wrapText="true"
+               text="Gestión de rescates, vacunas y estadísticas. Funciona sin conexión y sincroniza automáticamente."/>
+
+        <!-- Primary action plus shortcuts that skip a redundant navigation step -->
+        <VBox alignment="CENTER" spacing="14.0">
+            <padding><Insets top="10"/></padding>
+
+            <Button fx:id="continueButton"
+                    text="Comenzar  →"
+                    onAction="#handleContinue"
+                    defaultButton="true"
+                    styleClass="continue-button"/>
+
+            <HBox alignment="CENTER" spacing="12.0" styleClass="quick-actions">
+                <Button fx:id="animalsButton"
+                        text="🐶  Animales"
+                        onAction="#handleGoToAnimals"
+                        styleClass="quick-button"/>
+                <Button fx:id="statsButton"
+                        text="📊  Estadísticas"
+                        onAction="#handleGoToStatistics"
+                        styleClass="quick-button"/>
+            </HBox>
         </VBox>
-        <VBox alignment="CENTER" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0">
-            <ImageView fx:id="dogImageView" fitHeight="600.0" fitWidth="900.0" pickOnBounds="true" preserveRatio="true" styleClass="dog-image">
-                <image>
-                    <Image url="@/images/DogWelcomePage.png" />
-                </image>
-            </ImageView>
-        </VBox>
-    </children>
-</AnchorPane>
+
+        <!-- Connectivity badge: the app is offline-first, so whether it can sync
+             right now is genuinely useful to surface up front. -->
+        <HBox alignment="CENTER">
+            <padding><Insets top="8"/></padding>
+            <Label fx:id="statusBadge" text="Comprobando conexión…" styleClass="status-badge"/>
+        </HBox>
+    </VBox>
+</StackPane>


### PR DESCRIPTION
Unifies the whole app on the brand identity (orange `#F2921D` + brown `#593414`), keeping green for confirm and red for destructive actions. Chart series colors stay varied on purpose.

- Maps all off-brand accents (flat-UI blue, slate blue, emerald, purple, teal) to the brand palette.
- Tables: warm hover + orange selection rail, readable empty state; vaccines table no longer selects in blue.
- Sidebar: real `active` state for the current screen; no pixel shift on hover.
- Welcome/Splash: consistent Segoe UI typography and warmer backgrounds.
- Removes dead CSS (`@media` blocks unsupported by JavaFX, a duplicated `.scan-button` rule with a malformed `-text-fill`, an empty ruleset) and adds missing `:pressed` feedback.